### PR TITLE
pre-release 2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
     ```
 
 - JCenter
-    ``` xml
+    ``` java
     dependencies {
         /*
          * your other dependencies

--- a/README.md
+++ b/README.md
@@ -19,12 +19,19 @@
     <dependency>
         <groupId>cn.ucloud.ufile</groupId>
         <artifactId>ufile-client-java</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.6</version>
     </dependency>
     ```
 
 - JCenter
-    暂未提交JCenter仓库
+    ``` xml
+    dependencies {
+        /*
+         * your other dependencies
+         */
+        implementation 'cn.ucloud.ufile:ufile-client-java:2.0.6'
+    }
+    ```
 
 ## 快速入门
 
@@ -82,6 +89,9 @@ UfileClient.bucket(BUCKET_AUTHORIZER)
     ```
 
 ### 对象相关操作
+
+##### 关于ObjectConfig的region参数，是指您的bucket所创建在的地区编码，请参考[UCloud 地区列表](https://docs.ucloud.cn/api/summary/regionlist.html)
+
 ``` java
 // 对象相关API的授权器
 ObjectAuthorization OBJECT_AUTHORIZER = new UfileObjectLocalAuthorization(
@@ -101,7 +111,8 @@ ObjectAuthorization OBJECT_AUTHORIZER = new UfileObjectRemoteAuthorization(
 // 对象操作需要ObjectConfig来配置您的地区和域名后缀
 ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
 
-/** 您也可以使用已登记的自定义域名
+/** 
+ * 您也可以使用已登记的自定义域名
  * 注意'http://www.your_domain.com'指向的是某个特定的bucket+region+域名后缀，
  * eg：http://www.your_domain.com -> www.your_bucket.bucket_region.ufileos.com
  */

--- a/ufile-sample-java/pom.xml
+++ b/ufile-sample-java/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>cn.ucloud.ufile</groupId>
             <artifactId>ufile-client-java</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.6</version>
         </dependency>
     </dependencies>
 

--- a/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/DeleteObjectSample.java
+++ b/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/DeleteObjectSample.java
@@ -19,7 +19,7 @@ import okhttp3.Request;
  */
 public class DeleteObjectSample {
     private static final String TAG = "DeleteObjectSample";
-    private static ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
+    private static ObjectConfig config = new ObjectConfig("cn-sh2", "ufileos.com");
 
     public static void main(String[] args) {
         String keyName = "";

--- a/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/DownloadFileSample.java
+++ b/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/DownloadFileSample.java
@@ -22,7 +22,7 @@ import okhttp3.Request;
  */
 public class DownloadFileSample {
     private static final String TAG = "DownloadFileSample";
-    private static ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
+    private static ObjectConfig config = new ObjectConfig("cn-sh2", "ufileos.com");
 
     public static void main(String[] args) {
         String keyName = "";

--- a/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/GetObjectSample.java
+++ b/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/GetObjectSample.java
@@ -30,7 +30,7 @@ import java.io.OutputStream;
  */
 public class GetObjectSample {
     private static final String TAG = "GetObjectSample";
-    private static ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
+    private static ObjectConfig config = new ObjectConfig("cn-sh2", "ufileos.com");
 
     public static void main(String[] args) {
         String keyName = "";

--- a/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/ObjectListSample.java
+++ b/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/ObjectListSample.java
@@ -19,7 +19,7 @@ import okhttp3.Request;
  */
 public class ObjectListSample {
     private static final String TAG = "ObjectListSample";
-    private static ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
+    private static ObjectConfig config = new ObjectConfig("cn-sh2", "ufileos.com");
 
     public static void main(String[] args) {
         String bucketName = "";

--- a/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/ObjectProfileSample.java
+++ b/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/ObjectProfileSample.java
@@ -19,7 +19,7 @@ import okhttp3.Request;
  */
 public class ObjectProfileSample {
     private static final String TAG = "ObjectProfileSample";
-    private static ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
+    private static ObjectConfig config = new ObjectConfig("cn-sh2", "ufileos.com");
 
     public static void main(String[] args) {
         String keyName = "";

--- a/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/PutObjectSample.java
+++ b/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/PutObjectSample.java
@@ -22,7 +22,7 @@ import java.io.*;
  */
 public class PutObjectSample {
     private static final String TAG = "PutObjectSample";
-    private static ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
+    private static ObjectConfig config = new ObjectConfig("cn-sh2", "ufileos.com");
 
     public static void main(String[] args) {
         InputStream is = new ByteArrayInputStream(new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});

--- a/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/UploadHitSample.java
+++ b/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/UploadHitSample.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
  */
 public class UploadHitSample {
     private static final String TAG = "UploadHitSample";
-    private static ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
+    private static ObjectConfig config = new ObjectConfig("cn-sh2", "ufileos.com");
 
     public static void main(String[] args) {
         File file = new File("");

--- a/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/multi/MultiUploadSample.java
+++ b/ufile-sample-java/src/main/java/cn/ucloud/ufile/sample/object/multi/MultiUploadSample.java
@@ -27,7 +27,7 @@ import java.util.concurrent.*;
  */
 public class MultiUploadSample {
     private static final String TAG = "MultiUploadSample";
-    private static ObjectConfig config = new ObjectConfig("your bucket region", "ufileos.com");
+    private static ObjectConfig config = new ObjectConfig("cn-sh2", "ufileos.com");
 
     public static void main(String[] args) {
         File file = new File("");

--- a/ufile/pom.xml
+++ b/ufile/pom.xml
@@ -7,7 +7,7 @@
     <groupId>cn.ucloud.ufile</groupId>
     <artifactId>ufile</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
 
     <modules>
         <module>ufile-core</module>

--- a/ufile/ufile-client-java/pom.xml
+++ b/ufile/ufile-client-java/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <artifactId>ufile</artifactId>
         <groupId>cn.ucloud.ufile</groupId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
 
     <artifactId>ufile-client-java</artifactId>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
 
     <dependencies>
         <dependency>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>cn.ucloud.ufile</groupId>
             <artifactId>ufile-core</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.6</version>
         </dependency>
     </dependencies>
 

--- a/ufile/ufile-client-java/src/main/java/cn/ucloud/ufile/api/object/DownloadFileApi.java
+++ b/ufile/ufile-client-java/src/main/java/cn/ucloud/ufile/api/object/DownloadFileApi.java
@@ -486,15 +486,17 @@ public class DownloadFileApi extends UfileObjectApi<DownloadFileBean> {
             throw new UfileIOException("Occur IOException while IO stream");
         } finally {
             if (progressConfig.type == ProgressConfig.ProgressIntervalType.PROGRESS_INTERVAL_TIME) {
-                if (progressTask != null)
-                    progressTask.cancel();
-                if (progressTimer != null)
-                    progressTimer.cancel();
+                if (bytesWritten.get() <= total) {
+                    if (progressTask != null)
+                        progressTask.cancel();
+                    if (progressTimer != null)
+                        progressTimer.cancel();
 
-                if (onProgressListener != null)
-                    synchronized (bytesWritten) {
-                        onProgressListener.onProgress(bytesWritten.get(), total);
-                    }
+                    if (onProgressListener != null)
+                        synchronized (bytesWritten) {
+                            onProgressListener.onProgress(bytesWritten.get(), total);
+                        }
+                }
             }
             FileUtil.close(raf, is);
         }

--- a/ufile/ufile-client-java/src/main/java/cn/ucloud/ufile/api/object/DownloadFileApi.java
+++ b/ufile/ufile-client-java/src/main/java/cn/ucloud/ufile/api/object/DownloadFileApi.java
@@ -362,6 +362,18 @@ public class DownloadFileApi extends UfileObjectApi<DownloadFileBean> {
 
             List<Future<DownloadFileBean>> futures = mFixedThreadPool.invokeAll(callList);
 
+            if (progressConfig.type == ProgressConfig.ProgressIntervalType.PROGRESS_INTERVAL_TIME) {
+                if (progressTask != null)
+                    progressTask.cancel();
+                if (progressTimer != null)
+                    progressTimer.cancel();
+
+                if (onProgressListener != null)
+                    synchronized (bytesWritten) {
+                        onProgressListener.onProgress(bytesWritten.get(), totalSize);
+                    }
+            }
+
             return new DownloadFileBean()
                     .setContentType(profile.getContentType())
                     .seteTag(Etag.etag(finalFile, UfileConstants.MULTIPART_SIZE).geteTag())
@@ -393,6 +405,18 @@ public class DownloadFileApi extends UfileObjectApi<DownloadFileBean> {
                     }
 
                     List<Future<DownloadFileBean>> futures = mFixedThreadPool.invokeAll(callList);
+
+                    if (progressConfig.type == ProgressConfig.ProgressIntervalType.PROGRESS_INTERVAL_TIME) {
+                        if (progressTask != null)
+                            progressTask.cancel();
+                        if (progressTimer != null)
+                            progressTimer.cancel();
+
+                        if (onProgressListener != null)
+                            synchronized (bytesWritten) {
+                                onProgressListener.onProgress(bytesWritten.get(), totalSize);
+                            }
+                    }
 
                     if (httpCallback != null) {
                         try {
@@ -485,19 +509,6 @@ public class DownloadFileApi extends UfileObjectApi<DownloadFileBean> {
         } catch (IOException e) {
             throw new UfileIOException("Occur IOException while IO stream");
         } finally {
-            if (progressConfig.type == ProgressConfig.ProgressIntervalType.PROGRESS_INTERVAL_TIME) {
-                if (bytesWritten.get() <= total) {
-                    if (progressTask != null)
-                        progressTask.cancel();
-                    if (progressTimer != null)
-                        progressTimer.cancel();
-
-                    if (onProgressListener != null)
-                        synchronized (bytesWritten) {
-                            onProgressListener.onProgress(bytesWritten.get(), total);
-                        }
-                }
-            }
             FileUtil.close(raf, is);
         }
 

--- a/ufile/ufile-core/pom.xml
+++ b/ufile/ufile-core/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <artifactId>ufile</artifactId>
         <groupId>cn.ucloud.ufile</groupId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
 
     <artifactId>ufile-core</artifactId>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
 
     <dependencies>
         <dependency>

--- a/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/interceptor/LogInterceptor.java
+++ b/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/interceptor/LogInterceptor.java
@@ -46,15 +46,16 @@ public class LogInterceptor implements Interceptor {
         JLog.T(TAG, "[response-headers]:" + response.headers().toString());
 
         /* 获得返回的body，注意此处不要使用responseBody.string()获取返回数据，原因在于这个方法会消耗返回结果的数据(buffer) */
-        ResponseBody responseBody = response.body();
+//        ResponseBody responseBody = response.body();
+
         /* 为了不消耗buffer，我们这里使用source先获得buffer对象，然后clone()后使用 */
-        BufferedSource source = responseBody.source();
-        source.request(Long.MAX_VALUE); // Buffer the entire body.
-        /* 获得返回的数据 */
-        Buffer buffer = source.buffer();
-        if (buffer.size() < 1024)
-            /* 使用前clone() 下，避免直接消耗 */
-            JLog.T(TAG, "[response-body]:" + buffer.clone().readString(Charset.forName("UTF-8")));
+//        BufferedSource source = responseBody.source();
+//        source.request(Long.MAX_VALUE); // Buffer the entire body.
+//        /* 获得返回的数据 */
+//        Buffer buffer = source.buffer();
+//        if (buffer.size() < 1024)
+//            /* 使用前clone() 下，避免直接消耗 */
+//            JLog.T(TAG, "[response-body]:" + buffer.clone().readString(Charset.forName("UTF-8")));
 
         return response;
     }

--- a/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/PutFileRequestBuilder.java
+++ b/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/PutFileRequestBuilder.java
@@ -21,9 +21,11 @@ import java.util.HashMap;
 public class PutFileRequestBuilder extends HttpRequestBuilder<File> {
     private OnProgressListener onProgressListener;
     private ProgressConfig progressConfig;
+    private UploadFileRequestBody requestBody;
 
     public PutFileRequestBuilder(OnProgressListener onProgressListener) {
         this.onProgressListener = onProgressListener;
+        this.requestBody = new UploadFileRequestBody();
     }
 
     public PutFileRequestBuilder setProgressConfig(ProgressConfig progressConfig) {
@@ -31,9 +33,16 @@ public class PutFileRequestBuilder extends HttpRequestBuilder<File> {
         return this;
     }
 
+    public PutFileRequestBuilder setBufferSize(long bufferSize) {
+        this.requestBody.setBufferSize(bufferSize);
+        return this;
+    }
+
     @Override
     public Call build(OkHttpClient httpClient) {
-        UploadFileRequestBody requestBody = (UploadFileRequestBody) new UploadFileRequestBody(params, mediaType, onProgressListener)
+        this.requestBody.setContent(params)
+                .setContentType(mediaType)
+                .setOnProgressListener(onProgressListener)
                 .setProgressConfig(progressConfig == null ? ProgressConfig.callbackDefault() : progressConfig);
 
         if (header == null)

--- a/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/PutStreamRequestBuilder.java
+++ b/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/PutStreamRequestBuilder.java
@@ -21,9 +21,11 @@ import java.util.HashMap;
 public class PutStreamRequestBuilder extends HttpRequestBuilder<InputStream> {
     private OnProgressListener onProgressListener;
     private ProgressConfig progressConfig;
+    private UploadStreamRequestBody requestBody;
 
     public PutStreamRequestBuilder(OnProgressListener onProgressListener) {
         this.onProgressListener = onProgressListener;
+        this.requestBody = new UploadStreamRequestBody();
     }
 
     public PutStreamRequestBuilder setProgressConfig(ProgressConfig progressConfig) {
@@ -31,11 +33,19 @@ public class PutStreamRequestBuilder extends HttpRequestBuilder<InputStream> {
         return this;
     }
 
+    public PutStreamRequestBuilder setBufferSize(long bufferSize) {
+        this.requestBody.setBufferSize(bufferSize);
+        return this;
+    }
+
     @Override
     public Call build(OkHttpClient httpClient) {
-        UploadStreamRequestBody requestBody = (UploadStreamRequestBody) new UploadStreamRequestBody(params, mediaType,
-                Long.parseLong(header.getOrDefault("Content-Length", "0")), onProgressListener)
+        this.requestBody.setContent(params)
+                .setContentType(mediaType)
+                .setContentLength(Long.parseLong(header.getOrDefault("Content-Length", "0")))
+                .setOnProgressListener(onProgressListener)
                 .setProgressConfig(progressConfig == null ? ProgressConfig.callbackDefault() : progressConfig);
+
         if (header == null)
             header = new HashMap<>();
 

--- a/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/body/UploadFileRequestBody.java
+++ b/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/body/UploadFileRequestBody.java
@@ -16,6 +16,9 @@ import java.io.IOException;
  */
 public class UploadFileRequestBody extends UploadRequestBody<File> {
 
+    public UploadFileRequestBody() {
+    }
+
     /**
      * 构造方法
      *

--- a/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/body/UploadRequestBody.java
+++ b/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/body/UploadRequestBody.java
@@ -1,5 +1,6 @@
 package cn.ucloud.ufile.http.request.body;
 
+import cn.ucloud.ufile.UfileConstants;
 import cn.ucloud.ufile.http.OnProgressListener;
 import cn.ucloud.ufile.http.ProgressConfig;
 import cn.ucloud.ufile.util.FileUtil;
@@ -52,9 +53,9 @@ public abstract class UploadRequestBody<T> extends RequestBody {
     protected ProgressConfig progressConfig;
 
     /**
-     * 流写入的buffer大小，Default = 32 KB
+     * 流写入的buffer大小，Default = 256 KB
      */
-    protected long bufferSize = 32 << 10;
+    protected long bufferSize = UfileConstants.DEFAULT_BUFFER_SIZE;
 
     /**
      * 已写入的大小
@@ -89,6 +90,9 @@ public abstract class UploadRequestBody<T> extends RequestBody {
                 }
             }
         }
+    }
+
+    public UploadRequestBody() {
     }
 
     /**
@@ -135,6 +139,11 @@ public abstract class UploadRequestBody<T> extends RequestBody {
     @Override
     public long contentLength() {
         return contentLength;
+    }
+
+    public UploadRequestBody<T> setContentLength(long contentLength) {
+        this.contentLength = contentLength;
+        return this;
     }
 
     /**

--- a/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/body/UploadStreamRequestBody.java
+++ b/ufile/ufile-core/src/main/java/cn/ucloud/ufile/http/request/body/UploadStreamRequestBody.java
@@ -18,6 +18,9 @@ import java.io.InputStream;
  */
 public class UploadStreamRequestBody extends UploadRequestBody<InputStream> {
 
+    public UploadStreamRequestBody() {
+    }
+
     /**
      * 构造方法
      *
@@ -42,6 +45,8 @@ public class UploadStreamRequestBody extends UploadRequestBody<InputStream> {
         }
         return this;
     }
+
+
 
     @Override
     public void writeTo(BufferedSink sink) throws IOException {


### PR DESCRIPTION
1、为上传请求预留bufferSize可配置功能
2、优化分片下载按时间间隔回调进度时，每片下载完成，会多次回调进度的现象
3、修复下载时进度回调会在所有数据都已从网络加载到缓冲后才开始的bug，原因是由于为okhttp添加了日志拦截器导致，还需持续测试观察
4、修复分片下载按时间间隔回调进度时，某分片下载完毕后计时器停止的bug
5、生成私有下载路径加入异步调用，因如果采用远程签名服务，签名接口为同步调用，故无法真正异步
6、为数据bean类实现Serializable序列化接口，便于上层调用时传递数据结构
7、更新User-Agent
8、修复异步请求时内部若请求远程签名时是同步而导致android端在主线程调用异步接口时会崩溃的bug
9、修复分片上传sample中的bug
10、优化sample中的ObjectConfig的region参数默认项，给用户提示如何输入
11、修复ObjectConfig自定义域名不带http时的字符串拼接bug
12、为MimeType工具类加入根据文件名解析mimeType的方法
13、升级版本号2.0.6