### PR TITLE
在UfileServerException中添加getErrorBean方法，用于获取Server端业务逻辑异常的异常信息

### DIFF
--- a/ufile/ufile-core/src/main/java/cn/ucloud/ufile/exception/UfileServerException.java
+++ b/ufile/ufile-core/src/main/java/cn/ucloud/ufile/exception/UfileServerException.java
@@ -33,4 +33,8 @@ public class UfileServerException extends Exception {
     public UfileServerException(Throwable cause) {
         super(cause);
     }
+
+    public UfileErrorBean getErrorBean() {
+        return errorBean;
+    }
 }


### PR DESCRIPTION
- 在UfileServerException中添加getErrorBean方法，用于获取Server端业务逻辑异常的异常信息